### PR TITLE
Update MainActivity imports

### DIFF
--- a/app/src/main/java/com/example/vpn/MainActivity.kt
+++ b/app/src/main/java/com/example/vpn/MainActivity.kt
@@ -2,15 +2,15 @@ package com.example.vpn
 
 import android.net.VpnService
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
+import android.content.Intent
+import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import com.example.vpn.databinding.ActivityMainBinding
 import de.blinkt.openvpn.core.ProfileManager
 import de.blinkt.openvpn.core.VpnStatus        // если уже не импортирован
 import de.blinkt.openvpn.core.OpenVPNService  // понадобится в disconnect()
+import de.blinkt.openvpn.core.VpnProfile
 
 
 class MainActivity : AppCompatActivity() {


### PR DESCRIPTION
## Summary
- clean up unused imports in `MainActivity`
- add missing imports for Intent, Log, and VpnProfile

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606b521a2c8330837f3ace8207d38d