### PR TITLE
Add README noting sdk.dir requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# VPN Project
+
+This project requires an Android SDK for building and running tests. Gradle looks for the SDK location in the `local.properties` file at the project root. Ensure that `local.properties` defines the `sdk.dir` property before attempting to build or test.
+
+Example:
+
+```
+sdk.dir=/path/to/android/sdk
+```
+
+Replace the path with the installation directory of your Android SDK. If the file does not exist, create it with the appropriate entry.


### PR DESCRIPTION
## Summary
- document need for Android SDK path in `local.properties`

## Testing
- `bash gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68606b55acd4833088e8af85052fd106