### PR TITLE
Fix local OpenVPN library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,28 @@ Then you can build or test the project with:
 ```bash
 ./gradlew build
 ```
+
+## Using a local build of ICS OpenVPN
+
+If access to JitPack is unavailable, you can compile the OpenVPN library from a local clone. Clone the upstream project next to `app` and `gradle`:
+
+```bash
+git clone --branch v0.7.61 https://github.com/schwabe/ics-openvpn.git openvpn
+```
+
+Edit `openvpn/main/build.gradle.kts` and replace the `com.android.application` plugin with `com.android.library`. Optionally apply the `maven-publish` plugin and add a `publishing` block as described in the project guide.
+
+Build the archive:
+
+```bash
+cd openvpn
+./gradlew :main:assembleRelease
+```
+
+Copy the generated `main-release.aar` to `app/libs/openvpn-v0.7.61.aar` and add the dependency in `app/build.gradle.kts`:
+
+```kotlin
+implementation(files("libs/openvpn-v0.7.61.aar"))
+```
+
+Gradle will then resolve classes from the locally built AAR.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    id("com.android.library")
 }
 
 android {
@@ -53,13 +52,6 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-    implementation(
-        name = "openvpn-v0.7.61", ext = "aar",
-        group = TODO(),
-        version = TODO(),
-        configuration = TODO(),
-        classifier = TODO(),
-        dependencyConfiguration = TODO()
-    )
+    implementation(files("libs/openvpn-v0.7.61.aar"))
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
+        flatDir { dirs("app/libs") }
     }
 }
 


### PR DESCRIPTION
## Summary
- remove unused library plugin and TODO placeholders
- move prebuilt ICS OpenVPN archive to `app/libs`
- look for local AAR in Gradle settings
- add docs to compile ICS OpenVPN locally

## Testing
- `./gradlew help`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606f9e6be0833097b28a85b9f610ba